### PR TITLE
Add gRPC Pact tests

### DIFF
--- a/new-price-service-consumer/src/test/java/com/example/priceclient/grpc/GrpcPriceClientPactTest.java
+++ b/new-price-service-consumer/src/test/java/com/example/priceclient/grpc/GrpcPriceClientPactTest.java
@@ -1,0 +1,164 @@
+package com.example.priceclient.grpc;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactBuilder;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.consumer.junit5.ProviderType;
+import au.com.dius.pact.consumer.model.MockServerImplementation;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.V4Interaction;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.example.priceservice.grpc.GetAllPricesRequest;
+import com.example.priceservice.grpc.GetAllPricesResponse;
+import com.example.priceservice.grpc.GetPriceRequest;
+import com.example.priceservice.grpc.Price;
+import com.example.priceservice.grpc.PriceServiceGrpc;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+
+import static au.com.dius.pact.consumer.dsl.PactBuilder.filePath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pact consumer tests for the gRPC PriceService.
+ */
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "price-service-provider-grpc", providerType = ProviderType.SYNCH_MESSAGE, pactVersion = PactSpecVersion.V4)
+public class GrpcPriceClientPactTest {
+
+    @Pact(consumer = "new-price-service-consumer")
+    public V4Pact getAllPricesPact(PactBuilder builder) {
+        return builder
+                .usingPlugin("protobuf")
+                .given("prices exist")
+                .expectsToReceive("get all prices", "core/interaction/synchronous-message")
+                .with(Map.of(
+                        "pact:proto", filePath("../proto/price_service.proto"),
+                        "pact:content-type", "application/grpc",
+                        "pact:proto-service", "PriceService/GetAllPrices",
+                        "request", Map.of(
+                                "page", "matching(number, 1)",
+                                "size", "matching(number, 2)"
+                        ),
+                        "response", List.of(Map.of(
+                                "prices", List.of(Map.of(
+                                        "instrument_id", "matching(type, 'AAPL')",
+                                        "bid_price", "matching(number, 100.0)",
+                                        "ask_price", "matching(number, 101.0)",
+                                        "last_updated", Map.of(
+                                                "seconds", "matching(number, 0)",
+                                                "nanos", "matching(number, 0)"
+                                        )
+                                )),
+                                "total_count", "matching(number, 1)",
+                                "page", "matching(number, 1)",
+                                "size", "matching(number, 2)"
+                        ))
+                ))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getAllPricesPact")
+    @MockServerConfig(implementation = MockServerImplementation.Plugin, registryEntry = "protobuf/transport/grpc")
+    void testGetAllPrices(MockServer mockServer, V4Interaction.SynchronousMessages interaction) throws InvalidProtocolBufferException {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("127.0.0.1:" + mockServer.getPort())
+                .usePlaintext()
+                .build();
+        PriceServiceGrpc.PriceServiceBlockingStub stub = PriceServiceGrpc.newBlockingStub(channel);
+
+        GetAllPricesRequest request = GetAllPricesRequest.parseFrom(interaction.getRequest().getContents().getValue());
+        GetAllPricesResponse response = stub.getAllPrices(request);
+        assertThat(response.getPricesList()).isNotEmpty();
+        channel.shutdownNow();
+    }
+
+    @Pact(consumer = "new-price-service-consumer")
+    public V4Pact getPricePact(PactBuilder builder) {
+        return builder
+                .usingPlugin("protobuf")
+                .given("price with ID exists")
+                .expectsToReceive("get price", "core/interaction/synchronous-message")
+                .with(Map.of(
+                        "pact:proto", filePath("../proto/price_service.proto"),
+                        "pact:content-type", "application/grpc",
+                        "pact:proto-service", "PriceService/GetPrice",
+                        "request", Map.of(
+                                "instrument_id", "matching(type, 'AAPL')"
+                        ),
+                        "response", List.of(Map.of(
+                                "price", Map.of(
+                                        "instrument_id", "matching(type, 'AAPL')",
+                                        "bid_price", "matching(number, 100.0)",
+                                        "ask_price", "matching(number, 101.0)",
+                                        "last_updated", Map.of(
+                                                "seconds", "matching(number, 0)",
+                                                "nanos", "matching(number, 0)"
+                                        )
+                                )
+                        ))
+                ))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getPricePact")
+    @MockServerConfig(implementation = MockServerImplementation.Plugin, registryEntry = "protobuf/transport/grpc")
+    void testGetPrice(MockServer mockServer, V4Interaction.SynchronousMessages interaction) throws InvalidProtocolBufferException {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("127.0.0.1:" + mockServer.getPort())
+                .usePlaintext()
+                .build();
+        PriceServiceGrpc.PriceServiceBlockingStub stub = PriceServiceGrpc.newBlockingStub(channel);
+
+        GetPriceRequest request = GetPriceRequest.parseFrom(interaction.getRequest().getContents().getValue());
+        Price price = stub.getPrice(request).getPrice();
+        assertThat(price.getInstrumentId()).isEqualTo("AAPL");
+        channel.shutdownNow();
+    }
+
+    @Pact(consumer = "new-price-service-consumer")
+    public V4Pact getPriceNotFoundPact(PactBuilder builder) {
+        return builder
+                .usingPlugin("protobuf")
+                .given("price with ID UNKNOWN does not exist")
+                .expectsToReceive("get price not found", "core/interaction/synchronous-message")
+                .with(Map.of(
+                        "pact:proto", filePath("../proto/price_service.proto"),
+                        "pact:content-type", "application/grpc",
+                        "pact:proto-service", "PriceService/GetPrice",
+                        "request", Map.of(
+                                "instrument_id", "matching(type, 'UNKNOWN')"
+                        ),
+                        "responseMetadata", Map.of(
+                                "grpc-status", "NOT_FOUND",
+                                "grpc-message", "matching(type, 'Price not found')"
+                        )
+                ))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getPriceNotFoundPact")
+    @MockServerConfig(implementation = MockServerImplementation.Plugin, registryEntry = "protobuf/transport/grpc")
+    void testGetPriceNotFound(MockServer mockServer, V4Interaction.SynchronousMessages interaction) throws InvalidProtocolBufferException {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("127.0.0.1:" + mockServer.getPort())
+                .usePlaintext()
+                .build();
+        PriceServiceGrpc.PriceServiceBlockingStub stub = PriceServiceGrpc.newBlockingStub(channel);
+
+        GetPriceRequest request = GetPriceRequest.parseFrom(interaction.getRequest().getContents().getValue());
+        assertThatThrownBy(() -> stub.getPrice(request)).isInstanceOf(StatusRuntimeException.class);
+        channel.shutdownNow();
+    }
+}

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/grpc/GrpcPriceServiceProviderPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/grpc/GrpcPriceServiceProviderPactTest.java
@@ -1,0 +1,103 @@
+package com.example.priceservice.pact.grpc;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junit5.PluginTestTarget;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.StateChangeAction;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.example.priceservice.adapter.persistence.entity.PriceEntity;
+import com.example.priceservice.adapter.persistence.repository.PriceJpaRepository;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {"grpc.server.port=9091", "admin.username=admin", "admin.password=password"})
+@ExtendWith(SpringExtension.class)
+@Provider("price-service-provider-grpc")
+@PactFolder("../new-price-service-consumer/build/pacts")
+public class GrpcPriceServiceProviderPactTest {
+
+    @Autowired
+    private PriceJpaRepository priceJpaRepository;
+
+    @BeforeEach
+    void setUp(PactVerificationContext context) {
+        context.setTarget(new PluginTestTarget(Map.of(
+                "host", "localhost",
+                "port", 9091,
+                "transport", "grpc"
+        )));
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void verify(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    static ReentrantLock pricesExist = new ReentrantLock();
+
+    @State(value = "prices exist", action = StateChangeAction.SETUP)
+    @Transactional
+    public void pricesExist() throws InterruptedException {
+        if (pricesExist.tryLock(30, TimeUnit.SECONDS)) {
+            try {
+                priceJpaRepository.findById("AAPL").ifPresentOrElse(e -> {},
+                        () -> priceJpaRepository.save(PriceEntity.builder()
+                                .instrumentId("AAPL")
+                                .bidPrice(new BigDecimal("175.50"))
+                                .askPrice(new BigDecimal("175.75"))
+                                .lastUpdated(Instant.now())
+                                .build()));
+            } finally {
+                pricesExist.unlock();
+            }
+        }
+    }
+
+    @State(value = "price with ID exists", action = StateChangeAction.SETUP)
+    @Transactional
+    public Map<String, String> priceWithIdExists() {
+        var parameters = new HashMap<String, String>();
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.randomAlphabetic(4));
+        priceJpaRepository.findById(instrumentId).ifPresent(priceJpaRepository::delete);
+
+        PriceEntity apple = PriceEntity.builder()
+                .instrumentId(instrumentId)
+                .bidPrice(new BigDecimal("175.50"))
+                .askPrice(new BigDecimal("175.75"))
+                .lastUpdated(Instant.now())
+                .build();
+
+        priceJpaRepository.save(apple);
+        return parameters;
+    }
+
+    @State(value = "price with ID exists", action = StateChangeAction.TEARDOWN)
+    @Transactional
+    public void priceWithIdExistsCleanup(Map<String, String> parameters) {
+        Optional.ofNullable(parameters.get("instrumentId")).ifPresent(priceJpaRepository::deleteById);
+    }
+
+    @State("price with ID UNKNOWN does not exist")
+    @Transactional
+    public void priceUnknownDoesNotExist() {
+        priceJpaRepository.findById("UNKNOWN").ifPresent(priceJpaRepository::delete);
+    }
+}


### PR DESCRIPTION
## Summary
- add gRPC Pact consumer test suite
- add gRPC Pact provider verification suite

## Testing
- `./gradlew :new-price-service-consumer:test --tests "*GrpcPriceClientPactTest"` *(fails: java.net.SocketException)*


------
https://chatgpt.com/codex/tasks/task_e_684733291bdc8329a6c8bbac574becd2