### PR TITLE
Add Kafka protobuf messaging with Pact tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ You can run the complete workflow demonstration:
 make full-workflow
 ```
 
+### Kafka Messaging Using Protobuf
+
+The demo includes asynchronous communication over Kafka. The provider publishes
+`PriceUpdate` events encoded with Protocol Buffers and the new consumer subscribes
+to the same topic. Pact tests exercise this flow with the protobuf plugin. Scenarios
+related to ordering or delivery guarantees are better covered with integration tests.
+
 But suggest following the step-by-step instructions in the "Contract Testing Workflow Demonstration" section.
 
 ### 5. Implementing Your Own Contract Tests
@@ -195,6 +202,18 @@ Run the gRPC consumer tests with:
 ```bash
 ./gradlew :new-price-service-consumer:test
 ```
+
+#### Kafka protobuf contract tests
+
+The consumer also subscribes to price updates delivered via Kafka using Protocol Buffers. 
+Pact tests verify the structure of the `PriceUpdate` message with the protobuf plugin.
+Message ordering and Kafka-specific delivery semantics are out of scope for Pact and should be
+covered with integration tests using an embedded Kafka broker.
+
+Limitations of Pact for Kafka testing:
+- Ordering of events and delivery semantics are not verified.
+- Headers and partitioning metadata are ignored.
+- Long running streams should be tested with system or integration tests.
 
 ### pact-broker
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ make full-workflow
 
 The demo includes asynchronous communication over Kafka. The provider publishes
 `PriceUpdate` events encoded with Protocol Buffers and the new consumer subscribes
-to the same topic. Pact tests exercise this flow with the protobuf plugin. Scenarios
+to the same topic. The message schema is defined in [`proto/price_update.proto`](proto/price_update.proto).
+Pact tests exercise this flow with the protobuf plugin. Scenarios
 related to ordering or delivery guarantees are better covered with integration tests.
 
 But suggest following the step-by-step instructions in the "Contract Testing Workflow Demonstration" section.

--- a/new-price-service-consumer/src/main/java/com/example/priceclient/config/KafkaProtoConsumerConfig.java
+++ b/new-price-service-consumer/src/main/java/com/example/priceclient/config/KafkaProtoConsumerConfig.java
@@ -1,0 +1,37 @@
+package com.example.priceclient.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProtoConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, byte[]> protoConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> protoKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(protoConsumerFactory());
+        return factory;
+    }
+}

--- a/new-price-service-consumer/src/main/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumer.java
+++ b/new-price-service-consumer/src/main/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumer.java
@@ -1,0 +1,31 @@
+package com.example.priceclient.kafka;
+
+import com.example.priceservice.grpc.PriceUpdate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka consumer that processes protobuf price update events.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProtoPriceKafkaConsumer {
+
+    @KafkaListener(topics = "${price.kafka.topic:price-updates-proto}", groupId = "price-client-proto", containerFactory = "protoKafkaListenerContainerFactory")
+    public void listen(byte[] message) {
+        try {
+            PriceUpdate event = PriceUpdate.parseFrom(message);
+            processPriceUpdate(event);
+        } catch (Exception e) {
+            log.error("Failed to process protobuf price update", e);
+        }
+    }
+
+    void processPriceUpdate(PriceUpdate message) {
+        log.info("Received protobuf price update: {}", message);
+        // further processing logic would go here
+    }
+}

--- a/new-price-service-consumer/src/test/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumerPactTest.java
+++ b/new-price-service-consumer/src/test/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumerPactTest.java
@@ -41,7 +41,7 @@ public class ProtoPriceKafkaConsumerPactTest {
                 .expectsToReceive("price updated", "core/interaction/message")
                 .with(Map.of(
                         "message.contents", Map.of(
-                                "pact:proto", filePath("../proto/price_service.proto"),
+                                "pact:proto", filePath("../proto/price_update.proto"),
                                 "pact:message-type", "PriceUpdate",
                                 "pact:content-type", "application/protobuf",
                                 "price", Map.of(

--- a/new-price-service-consumer/src/test/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumerPactTest.java
+++ b/new-price-service-consumer/src/test/java/com/example/priceclient/kafka/ProtoPriceKafkaConsumerPactTest.java
@@ -1,0 +1,69 @@
+package com.example.priceclient.kafka;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.dsl.PactBuilder;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.consumer.junit5.ProviderType;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.Message;
+import com.example.priceservice.grpc.PriceUpdate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static au.com.dius.pact.consumer.dsl.PactBuilder.filePath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "price-service-provider-kafka-proto", providerType = ProviderType.ASYNCH, pactVersion = PactSpecVersion.V4)
+@SpringBootTest(properties = "spring.autoconfigure.exclude=net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration")
+public class ProtoPriceKafkaConsumerPactTest {
+    @SpyBean
+    private ProtoPriceKafkaConsumer consumer;
+    @Captor
+    ArgumentCaptor<PriceUpdate> priceUpdateCaptor;
+
+    @Pact(consumer = "new-price-service-consumer")
+    public V4Pact priceUpdatePact(PactBuilder builder) {
+        return builder
+                .usingPlugin("protobuf")
+                .given("price update event")
+                .expectsToReceive("price updated", "core/interaction/message")
+                .with(Map.of(
+                        "message.contents", Map.of(
+                                "pact:proto", filePath("../proto/price_service.proto"),
+                                "pact:message-type", "PriceUpdate",
+                                "pact:content-type", "application/protobuf",
+                                "price", Map.of(
+                                        "instrument_id", "AAPL",
+                                        "bid_price", "matching(number, 175.50)",
+                                        "ask_price", "matching(number, 175.75)"
+                                ),
+                                "update_type", "UPDATED"
+                        )
+                ))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "priceUpdatePact")
+    void testConsumePriceUpdate(List<Message> messages) throws Exception {
+        consumer.listen(messages.getFirst().contentsAsBytes());
+        verify(consumer).processPriceUpdate(priceUpdateCaptor.capture());
+        var value = priceUpdateCaptor.getValue();
+        com.example.priceservice.grpc.Price price = value.getPrice();
+        assertThat(price.getInstrumentId()).isEqualTo("AAPL");
+        assertThat(price.getBidPrice()).isEqualTo(175.50);
+        assertThat(price.getAskPrice()).isEqualTo(175.75);
+    }
+}

--- a/price-service-provider/src/main/java/com/example/priceservice/config/KafkaProducerConfig.java
+++ b/price-service-provider/src/main/java/com/example/priceservice/config/KafkaProducerConfig.java
@@ -1,6 +1,7 @@
 package com.example.priceservice.config;
 
 import com.example.priceservice.kafka.PriceUpdateMessage;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,5 +33,19 @@ public class KafkaProducerConfig {
     @Bean
     public KafkaTemplate<String, PriceUpdateMessage> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, byte[]> protoProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, byte[]> protoKafkaTemplate() {
+        return new KafkaTemplate<>(protoProducerFactory());
     }
 }

--- a/price-service-provider/src/main/java/com/example/priceservice/kafka/ProtoPriceKafkaProducer.java
+++ b/price-service-provider/src/main/java/com/example/priceservice/kafka/ProtoPriceKafkaProducer.java
@@ -1,0 +1,43 @@
+package com.example.priceservice.kafka;
+
+import com.example.priceservice.domain.model.Price;
+import com.example.priceservice.grpc.PriceUpdate;
+import com.example.priceservice.grpc.UpdateType;
+import com.google.protobuf.Timestamp;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka producer that publishes price updates encoded with Protocol Buffers.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProtoPriceKafkaProducer {
+
+    private final KafkaTemplate<String, byte[]> protoKafkaTemplate;
+
+    @Value("${price.kafka.topic:price-updates-proto}")
+    private String topic;
+
+    public void sendPriceUpdate(com.example.priceservice.domain.model.Price price) {
+        com.example.priceservice.grpc.Price priceMsg = com.example.priceservice.grpc.Price.newBuilder()
+                .setInstrumentId(price.getInstrumentId())
+                .setBidPrice(price.getBidPrice().doubleValue())
+                .setAskPrice(price.getAskPrice().doubleValue())
+                .setLastUpdated(Timestamp.newBuilder()
+                        .setSeconds(price.getLastUpdated().getEpochSecond())
+                        .setNanos(price.getLastUpdated().getNano())
+                        .build())
+                .build();
+        PriceUpdate message = PriceUpdate.newBuilder()
+                .setPrice(priceMsg)
+                .setUpdateType(UpdateType.UPDATED)
+                .build();
+        protoKafkaTemplate.send(topic, price.getInstrumentId(), message.toByteArray());
+        log.info("Sent protobuf price update to Kafka: {}", message);
+    }
+}

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderProtoKafkaPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderProtoKafkaPactTest.java
@@ -1,0 +1,91 @@
+package com.example.priceservice.pact;
+
+import au.com.dius.pact.core.model.Interaction;
+import au.com.dius.pact.core.model.Pact;
+import au.com.dius.pact.provider.MessageAndMetadata;
+import au.com.dius.pact.provider.PactVerifyProvider;
+import au.com.dius.pact.provider.junit5.MessageTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.StateChangeAction;
+import au.com.dius.pact.provider.junitsupport.loader.*;
+import com.example.priceservice.domain.model.Price;
+import com.example.priceservice.grpc.PriceUpdate;
+import com.example.priceservice.grpc.UpdateType;
+import com.google.protobuf.Timestamp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+
+/**
+ * Provider verification for protobuf Kafka price update messages.
+ */
+@Provider("price-service-provider-kafka-proto")
+@PactBroker(
+        url = "${PACT_URL:http://localhost:9292}",
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USER:pact}", password = "${PACT_BROKER_PASSWORD:pact}"),
+        providerBranch = "${GIT_BRANCH:master}"
+)
+@VersionSelector
+@SpringBootTest
+public class PriceServiceProviderProtoKafkaPactTest {
+
+    @PactBrokerConsumerVersionSelectors
+    public static SelectorBuilder consumerVersionSelectors() {
+        return new SelectorBuilder()
+                .mainBranch()
+                .latestTag("dev");
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void testTemplate(Pact pact, Interaction interaction, PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        context.setTarget(new MessageTestTarget());
+    }
+
+    @State(value = "price update event", action = StateChangeAction.SETUP)
+    public Map<String, String> priceUpdateExists() {
+        return new HashMap<>();
+    }
+
+    @PactVerifyProvider("price updated")
+    public MessageAndMetadata verifyPriceUpdatedMessage() {
+        Price price = Price.builder()
+                .instrumentId(randomAlphabetic(4))
+                .bidPrice(new BigDecimal("10"))
+                .askPrice(new BigDecimal("11"))
+                .lastUpdated(Instant.now())
+                .build();
+        com.example.priceservice.grpc.Price priceMsg = com.example.priceservice.grpc.Price.newBuilder()
+                .setInstrumentId(price.getInstrumentId())
+                .setBidPrice(price.getBidPrice().doubleValue())
+                .setAskPrice(price.getAskPrice().doubleValue())
+                .setLastUpdated(Timestamp.newBuilder()
+                        .setSeconds(price.getLastUpdated().getEpochSecond())
+                        .setNanos(price.getLastUpdated().getNano())
+                        .build())
+                .build();
+        PriceUpdate message = PriceUpdate.newBuilder()
+                .setPrice(priceMsg)
+                .setUpdateType(UpdateType.UPDATED)
+                .build();
+        var metadata = new HashMap<String, Object>();
+        metadata.put("contentType", "application/protobuf");
+        return new MessageAndMetadata(message.toByteArray(), metadata);
+    }
+}

--- a/proto/price_service.proto
+++ b/proto/price_service.proto
@@ -7,6 +7,7 @@ option java_package = "com.example.priceservice.grpc";
 option java_outer_classname = "PriceServiceProto";
 
 import "google/protobuf/timestamp.proto";
+import "price_update.proto";
 
 // Price Service gRPC API
 // Provides methods for retrieving and managing financial instrument prices
@@ -21,13 +22,6 @@ service PriceService {
   rpc StreamPrices(StreamPricesRequest) returns (stream PriceUpdate);
 }
 
-// Price-related messages
-message Price {
-  string instrument_id = 1;
-  double bid_price = 2;
-  double ask_price = 3;
-  google.protobuf.Timestamp last_updated = 4;
-}
 
 message GetAllPricesRequest {
   // Optional pagination parameters
@@ -54,17 +48,7 @@ message StreamPricesRequest {
   repeated string instrument_ids = 1;
 }
 
-message PriceUpdate {
-  Price price = 1;
-  UpdateType update_type = 2;
-}
-
 // Common enums and messages
-enum UpdateType {
-  CREATED = 0;
-  UPDATED = 1;
-  DELETED = 2;
-}
 
 // Error handling
 message ErrorResponse {

--- a/proto/price_update.proto
+++ b/proto/price_update.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package com.example.priceservice.grpc;
+
+option java_multiple_files = true;
+option java_package = "com.example.priceservice.grpc";
+option java_outer_classname = "PriceUpdateProto";
+
+import "google/protobuf/timestamp.proto";
+
+message Price {
+  string instrument_id = 1;
+  double bid_price = 2;
+  double ask_price = 3;
+  google.protobuf.Timestamp last_updated = 4;
+}
+
+enum UpdateType {
+  CREATED = 0;
+  UPDATED = 1;
+  DELETED = 2;
+}
+
+message PriceUpdate {
+  Price price = 1;
+  UpdateType update_type = 2;
+}


### PR DESCRIPTION
## Summary
- add proto-based Kafka producer
- create proto Kafka consumer and config
- verify protobuf messages with new Pact tests
- document Protobuf Kafka messaging and its limitations

## Testing
- `./gradlew test --no-daemon` *(fails: Execution failed for task ':price-service-provider:test')*

------
https://chatgpt.com/codex/tasks/task_e_6849192e503083299073f96e1d2fb96d