### PR TITLE
Enhance test data generation with secure factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,9 @@ This ensures that the security requirements are properly verified through contra
 5. **Use Dynamic State Management**
    - Create test data dynamically for each test
    - Avoid relying on pre-existing data
+6. **Generate Secure Test Identifiers**
+   - Use `TestDataFactory.randomInstrumentId()` for unique IDs
+   - Enable deterministic mode with `-Dtest.deterministic=true` when debugging
 
 ## Common Pitfalls and Solutions
 
@@ -495,8 +498,8 @@ This ensures that the security requirements are properly verified through contra
   @State(value = "price with ID exists")
   public Map<String, String> priceWithIdExists() {
       var parameters = new HashMap<String, String>();
-      var instrumentId = parameters.computeIfAbsent("instrumentId", 
-          id -> RandomStringUtils.secure().nextAlphanumeric(4));
+      var instrumentId = parameters.computeIfAbsent("instrumentId",
+          id -> TestDataFactory.randomInstrumentId());
       // Setup code using instrumentId
       return parameters;
   }

--- a/README_ru.md
+++ b/README_ru.md
@@ -419,6 +419,9 @@ public void priceWithIdAaplExists() {
 5. **Используйте динамическое управление состоянием**
    - Создавайте тестовые данные динамически для каждого теста
    - Избегайте зависимости от предварительно существующих данных
+6. **Генерируйте безопасные идентификаторы тестовых данных**
+   - Используйте `TestDataFactory.randomInstrumentId()` для уникальных ID
+   - Для детерминированного режима задайте `-Dtest.deterministic=true`
 
 ## Распространенные проблемы и решения
 
@@ -458,8 +461,8 @@ public void priceWithIdAaplExists() {
   @State(value = "price with ID exists")
   public Map<String, String> priceWithIdExists() {
       var parameters = new HashMap<String, String>();
-      var instrumentId = parameters.computeIfAbsent("instrumentId", 
-          id -> RandomStringUtils.secure().nextAlphanumeric(4));
+      var instrumentId = parameters.computeIfAbsent("instrumentId",
+          id -> TestDataFactory.randomInstrumentId());
       // Код настройки с использованием instrumentId
       return parameters;
   }

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderGrpcPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderGrpcPactTest.java
@@ -9,7 +9,7 @@ import au.com.dius.pact.provider.junitsupport.StateChangeAction;
 import au.com.dius.pact.provider.junitsupport.loader.*;
 import com.example.priceservice.adapter.persistence.entity.PriceEntity;
 import com.example.priceservice.adapter.persistence.repository.PriceJpaRepository;
-import org.apache.commons.lang3.RandomStringUtils;
+import com.example.priceservice.util.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,7 +97,7 @@ public class PriceServiceProviderGrpcPactTest {
     @Transactional
     public Map<String, String> priceWithIdExists(Map<String, String> param) {
         var parameters = new HashMap<>(param);
-        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.secure().nextAlphanumeric(4));
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> TestDataFactory.randomInstrumentId());
         priceJpaRepository.findById(instrumentId).ifPresent(price -> priceJpaRepository.delete(price));
         var price = PriceEntity.builder()
                 .instrumentId(instrumentId)

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderKafkaPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderKafkaPactTest.java
@@ -28,7 +28,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import com.example.priceservice.util.TestDataFactory;
 
 /**
  * Provider side verification for Kafka price update messages.
@@ -77,7 +77,7 @@ public class PriceServiceProviderKafkaPactTest {
         // Build a representative domain object and convert it to the Kafka message
         // Создаем доменный объект и конвертируем его в Kafka-сообщение
         Price price = Price.builder()
-                .instrumentId(randomAlphabetic(4))
+                .instrumentId(TestDataFactory.randomInstrumentId())
                 .bidPrice(new BigDecimal("10"))
                 .askPrice(new BigDecimal("11"))
                 .lastUpdated(Instant.now())

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderOrderbookPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderOrderbookPactTest.java
@@ -10,7 +10,7 @@ import au.com.dius.pact.provider.junitsupport.loader.*;
 import com.example.priceservice.adapter.persistence.entity.OrderBookEntity;
 import com.example.priceservice.adapter.persistence.entity.OrderEntity;
 import com.example.priceservice.adapter.persistence.repository.OrderBookJpaRepository;
-import org.apache.commons.lang3.RandomStringUtils;
+import com.example.priceservice.util.TestDataFactory;
 import org.apache.hc.core5.http.HttpRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -149,7 +149,7 @@ public class PriceServiceProviderOrderbookPactTest {
         // Clear existing data for this ID
         // Очистка существующих данных для этого ID
         var parameters = new HashMap<String, String>();
-        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.secure().nextAlphanumeric(4));
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> TestDataFactory.randomInstrumentId());
         orderBookJpaRepository.findById(instrumentId).ifPresent(orderBook -> orderBookJpaRepository.delete(orderBook));
 
         // Create test data
@@ -241,7 +241,7 @@ public class PriceServiceProviderOrderbookPactTest {
         // Clear existing data for this ID
         // Очистка существующих данных для этого ID
         var parameters = new HashMap<String, String>();
-        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.secure().nextAlphanumeric(4));
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> TestDataFactory.randomInstrumentId());
         orderBookJpaRepository.findById(instrumentId).ifPresent(orderBook -> orderBookJpaRepository.delete(orderBook));
         return parameters;
     }

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderPricePactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderPricePactTest.java
@@ -9,7 +9,7 @@ import au.com.dius.pact.provider.junitsupport.StateChangeAction;
 import au.com.dius.pact.provider.junitsupport.loader.*;
 import com.example.priceservice.adapter.persistence.entity.PriceEntity;
 import com.example.priceservice.adapter.persistence.repository.PriceJpaRepository;
-import org.apache.commons.lang3.RandomStringUtils;
+import com.example.priceservice.util.TestDataFactory;
 import org.apache.hc.core5.http.HttpRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -202,7 +202,7 @@ public class PriceServiceProviderPricePactTest {
         // Clear existing data for this ID
         // Очистка существующих данных для этого ID
         var parameters = new HashMap<String, String>();
-        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.secure().nextAlphanumeric(4));
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> TestDataFactory.randomInstrumentId());
         priceJpaRepository.findById(instrumentId).ifPresent(price -> priceJpaRepository.delete(price));
 
         // Create test data
@@ -264,7 +264,7 @@ public class PriceServiceProviderPricePactTest {
         // No specific setup needed as the repository allows saving
         // Специальная настройка не требуется, так как репозиторий позволяет сохранять
         var parameters = new HashMap<String, String>();
-        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> RandomStringUtils.secure().nextAlphanumeric(4));
+        var instrumentId = parameters.computeIfAbsent("instrumentId", id -> TestDataFactory.randomInstrumentId());
         priceJpaRepository.deleteById(instrumentId);
         return parameters;
     }

--- a/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderProtoKafkaPactTest.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/pact/PriceServiceProviderProtoKafkaPactTest.java
@@ -23,7 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import com.example.priceservice.util.TestDataFactory;
 
 /**
  * Provider verification for protobuf Kafka price update messages.
@@ -65,7 +65,7 @@ public class PriceServiceProviderProtoKafkaPactTest {
     @PactVerifyProvider("proto price updated")
     public MessageAndMetadata verifyPriceUpdatedMessage() {
         Price priceMsg = Price.newBuilder()
-                .setInstrumentId(randomAlphabetic(4))
+                .setInstrumentId(TestDataFactory.randomInstrumentId())
                 .setBidPrice(10)
                 .setAskPrice(11)
                 .setLastUpdated(Timestamp.getDefaultInstance())

--- a/price-service-provider/src/test/java/com/example/priceservice/util/TestDataFactory.java
+++ b/price-service-provider/src/test/java/com/example/priceservice/util/TestDataFactory.java
@@ -1,0 +1,47 @@
+package com.example.priceservice.util;
+
+import java.security.SecureRandom;
+
+/**
+ * Utility for generating random test data using {@link SecureRandom}.
+ * <p>
+ * If the {@code test.deterministic} system property is set to {@code true},
+ * the generator will use a fixed seed so that values are repeatable.
+ */
+public final class TestDataFactory {
+    private static final String DETERMINISTIC_PROPERTY = "test.deterministic";
+    private static final SecureRandom RANDOM;
+    private static final char[] ALPHANUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+
+    static {
+        if (Boolean.getBoolean(DETERMINISTIC_PROPERTY)) {
+            RANDOM = new SecureRandom(new byte[] {0,1,2,3,4,5,6,7});
+            RANDOM.setSeed(0L);
+        } else {
+            RANDOM = new SecureRandom();
+        }
+    }
+
+    private TestDataFactory() {
+    }
+
+    /**
+     * Generates a random alphanumeric instrument id.
+     *
+     * @return unique id value
+     */
+    public static String randomInstrumentId() {
+        return randomInstrumentId(6);
+    }
+
+    /**
+     * Generates a random alphanumeric instrument id of given length.
+     */
+    public static String randomInstrumentId(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(ALPHANUM[RANDOM.nextInt(ALPHANUM.length)]);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TestDataFactory` for SecureRandom-based identifiers
- use the factory in provider pact tests
- update troubleshooting docs with secure generation example
- document deterministic mode for debugging

## Testing
- `./gradlew test --no-build-cache` *(fails: Task :price-service-consumer:test FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_684be10a5f708329a0cf17cd1d63360d